### PR TITLE
Get loadingStrategy value from netlify.toml inputs, default to 'lazy' if not provided

### DIFF
--- a/netlify-plugin-cloudinary/src/index.ts
+++ b/netlify-plugin-cloudinary/src/index.ts
@@ -127,6 +127,8 @@ export async function onBuild({
   }
 
   console.log(`[Cloudinary] Using host: ${host}`);
+  console.log('PUBLISH_DIR', constants["PUBLISH_DIR"])
+  // console.log('NETLIFYCONFIG', netlifyConfig['redirects'])
 
   const { PUBLISH_DIR } = constants;
 
@@ -277,7 +279,7 @@ export async function onBuild({
           }
 
           mediaPaths.forEach(async mediaPath => {
-            const cldAssetPath = `/${path.join(PUBLIC_ASSET_PATH, mediaPath)}`;
+            const cldAssetPath = `/${path.posix.join(PUBLIC_ASSET_PATH, mediaPath)}`;
             const cldAssetUrl = `${host}${cldAssetPath}`;
             try {
               const { cloudinaryUrl: assetRedirectUrl } = await getCloudinaryUrl({

--- a/netlify-plugin-cloudinary/src/index.ts
+++ b/netlify-plugin-cloudinary/src/index.ts
@@ -127,8 +127,6 @@ export async function onBuild({
   }
 
   console.log(`[Cloudinary] Using host: ${host}`);
-  console.log('PUBLISH_DIR', constants["PUBLISH_DIR"])
-  // console.log('NETLIFYCONFIG', netlifyConfig['redirects'])
 
   const { PUBLISH_DIR } = constants;
 

--- a/netlify-plugin-cloudinary/src/index.ts
+++ b/netlify-plugin-cloudinary/src/index.ts
@@ -335,6 +335,7 @@ export async function onPostBuild({
     cname,
     deliveryType,
     folder = process.env.SITE_NAME,
+    loadingStrategy = inputs.loadingStrategy || 'lazy',
     privateCdn,
     uploadPreset,
   } = inputs;
@@ -387,6 +388,7 @@ export async function onPostBuild({
         deliveryType,
         uploadPreset,
         folder,
+        loadingStrategy,
         localDir: PUBLISH_DIR,
         remoteHost: host,
         transformations

--- a/netlify-plugin-cloudinary/src/lib/cloudinary.ts
+++ b/netlify-plugin-cloudinary/src/lib/cloudinary.ts
@@ -70,7 +70,7 @@ export type Assets = {
 
 type UpdateCloudinaryOptions = Omit<CloudinaryOptions, 'path'> & {
   assets: Assets;
-  loadingStrategy?: "lazy"
+  loadingStrategy: string;
 }
 
 /**
@@ -288,7 +288,7 @@ export async function updateHtmlImagesToCloudinary(html: string, options: Update
     folder,
     localDir,
     remoteHost,
-    loadingStrategy = 'lazy',
+    loadingStrategy,
     transformations
   } = options
 

--- a/netlify-plugin-cloudinary/tests/lib/cloudinary-cname.test.js
+++ b/netlify-plugin-cloudinary/tests/lib/cloudinary-cname.test.js
@@ -49,7 +49,8 @@ describe('lib/util', () => {
       const { html } = await updateHtmlImagesToCloudinary(sourceHtml, {
         deliveryType: 'fetch',
         localDir: 'tests',
-        remoteHost: 'https://cloudinary.netlify.app'
+        remoteHost: 'https://cloudinary.netlify.app',
+        loadingStrategy: 'lazy'
       });
 
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://${cname}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg\" loading=\"lazy"\></p></body></html>`);

--- a/netlify-plugin-cloudinary/tests/lib/cloudinary-privatecdn.test.js
+++ b/netlify-plugin-cloudinary/tests/lib/cloudinary-privatecdn.test.js
@@ -48,7 +48,8 @@ describe('lib/util', () => {
       const { html } = await updateHtmlImagesToCloudinary(sourceHtml, {
         deliveryType: 'fetch',
         localDir: 'tests',
-        remoteHost: 'https://cloudinary.netlify.app'
+        remoteHost: 'https://cloudinary.netlify.app',
+        loadingStrategy: 'lazy'
       });
 
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://${process.env.CLOUDINARY_CLOUD_NAME}-res.cloudinary.com/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg\" loading=\"lazy"\></p></body></html>`);

--- a/netlify-plugin-cloudinary/tests/lib/cloudinary.test.js
+++ b/netlify-plugin-cloudinary/tests/lib/cloudinary.test.js
@@ -184,19 +184,6 @@ describe('lib/util', () => {
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg\" srcset=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg 1x, https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg 2x\" loading=\"lazy"\></p></body></html>`);
     });
 
-    it('should add lazy loading to image when no option is provided', async () => {
-      const sourceHtml = '<html><head></head><body><p><img src="https://i.imgur.com/vtYmp1x.png"></p></body></html>';
-
-      const { html } = await updateHtmlImagesToCloudinary(sourceHtml, {
-        deliveryType: 'fetch',
-        localDir: 'tests',
-        remoteHost: 'https://cloudinary.netlify.app',
-        loadingStrategy: 'lazy'
-      });
-
-      expect(html).toEqual(`<html><head></head><body><p><img src=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://i.imgur.com/vtYmp1x.png\" loading=\"lazy"\></p></body></html>`);
-    });
-
     it('should add eager loading to image when eager option is provided for loadingStrategy', async () => {
       const sourceHtml = '<html><head></head><body><p><img src="https://i.imgur.com/vtYmp1x.png"></p></body></html>';
 

--- a/netlify-plugin-cloudinary/tests/lib/cloudinary.test.js
+++ b/netlify-plugin-cloudinary/tests/lib/cloudinary.test.js
@@ -152,7 +152,8 @@ describe('lib/util', () => {
       const { html } = await updateHtmlImagesToCloudinary(sourceHtml, {
         deliveryType: 'fetch',
         localDir: 'tests',
-        remoteHost: 'https://cloudinary.netlify.app'
+        remoteHost: 'https://cloudinary.netlify.app',
+        loadingStrategy: 'lazy'
       });
 
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg\" loading=\"lazy"\></p></body></html>`);
@@ -162,7 +163,8 @@ describe('lib/util', () => {
       const sourceHtml = '<html><head></head><body><p><img src="https://i.imgur.com/vtYmp1x.png"></p></body></html>';
 
       const { html } = await updateHtmlImagesToCloudinary(sourceHtml, {
-        deliveryType: 'fetch'
+        deliveryType: 'fetch',
+        loadingStrategy: 'lazy'
       });
 
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://i.imgur.com/vtYmp1x.png\" loading=\"lazy"\></p></body></html>`);
@@ -176,6 +178,7 @@ describe('lib/util', () => {
         deliveryType: 'fetch',
         localDir: 'tests',
         remoteHost: 'https://cloudinary.netlify.app',
+        loadingStrategy: 'lazy'
       });
 
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg\" srcset=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg 1x, https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://cloudinary.netlify.app/images/stranger-things-dustin.jpeg 2x\" loading=\"lazy"\></p></body></html>`);
@@ -188,6 +191,7 @@ describe('lib/util', () => {
         deliveryType: 'fetch',
         localDir: 'tests',
         remoteHost: 'https://cloudinary.netlify.app',
+        loadingStrategy: 'lazy'
       });
 
       expect(html).toEqual(`<html><head></head><body><p><img src=\"https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/fetch/f_auto,q_auto/https://i.imgur.com/vtYmp1x.png\" loading=\"lazy"\></p></body></html>`);
@@ -213,6 +217,7 @@ describe('lib/util', () => {
         deliveryType: 'upload',
         localDir: 'demo/.next',
         remoteHost: 'https://main--netlify-plugin-cloudinary.netlify.app',
+        loadingStrategy: 'lazy',
         folder: 'netlify-plugin-cloudinary',
         assets: mockDemo.assets
       });

--- a/netlify-plugin-cloudinary/tests/on-post-build.test.js
+++ b/netlify-plugin-cloudinary/tests/on-post-build.test.js
@@ -6,6 +6,9 @@ import { onPostBuild } from '../src/';
 
 const mocksPath = path.join(__dirname, 'mocks/html');
 const tempPath = path.join(mocksPath, 'temp');
+// Avoid illegal characters in file paths, all operating systems
+const replaceRegEx = /[\W_]+/g
+const replaceValue = '_'
 
 async function mkdir(directoryPath) {
   let dir;
@@ -36,7 +39,7 @@ describe('onPostBuild', () => {
     process.env.CLOUDINARY_API_SECRET = 'abcd1234';
 
     const mockFiles = (await fs.readdir(mocksPath)).filter(filePath => filePath.includes('.html'));
-    const tempTestPath = path.join(tempPath, expect.getState().currentTestName.replace('/', '_'));
+    const tempTestPath = path.join(tempPath, expect.getState().currentTestName.replace(replaceRegEx, replaceValue));
     await mkdir(tempTestPath);
     await Promise.all(mockFiles.map(async file => {
       await fs.copyFile(path.join(mocksPath, file), path.join(tempTestPath, file));
@@ -46,7 +49,7 @@ describe('onPostBuild', () => {
   afterEach(async () => {
     process.env = ENV_ORIGINAL;
 
-    await fs.rm(path.join(tempPath, expect.getState().currentTestName.replace('/', '_')), { recursive: true, force: true });
+    await fs.rm(path.join(tempPath, expect.getState().currentTestName.replace(replaceRegEx, replaceValue)), { recursive: true, force: true });
   });
 
   afterAll(async () => {
@@ -66,7 +69,7 @@ describe('onPostBuild', () => {
 
       const deliveryType = 'fetch';
 
-      const tempTestPath = path.join(tempPath, expect.getState().currentTestName.replace('/', '_'));
+      const tempTestPath = path.join(tempPath, expect.getState().currentTestName.replace(replaceRegEx, replaceValue));
 
       await onPostBuild({
         constants: {
@@ -105,7 +108,7 @@ describe('onPostBuild', () => {
 
       const deliveryType = 'fetch';
 
-      const tempTestPath = path.join(tempPath, expect.getState().currentTestName.replace('/', '_'));
+      const tempTestPath = path.join(tempPath, expect.getState().currentTestName.replace(replaceRegEx, replaceValue));
 
       const maxSize = {
         width: 800,


### PR DESCRIPTION
## Description
loadingStrategy was not being read from the netlify.toml; this PR gets the value from the netlify.toml and if it doesn't exist, it defaults to `lazy`.

## Issue Ticket Number
Fixes https://github.com/cloudinary-community/netlify-plugin-cloudinary/issues/97

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

## Checklist
- [X]  I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](https://github.com/cloudinary-community/netlify-plugin-cloudinary/blob/main/CONTRIBUTING.md)
- [X]  I have created an [issue](https://github.com/colbyfayock/netlify-plugin-cloudinary/issues) ticket for this PR
- [X]  I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/netlify-plugin-cloudinary/pulls) for the same update/change?
- [X]  I have performed a self-review of my own code
- [X]  I have run tests locally to ensure they all pass
- [X]  I have commented my code, particularly in hard-to-understand areas
- [X]  I have made corresponding changes needed to the documentation
