### PR TITLE
Support Automated Image Scaling with Client Hints

### DIFF
--- a/netlify-plugin-cloudinary/src/lib/cloudinary.ts
+++ b/netlify-plugin-cloudinary/src/lib/cloudinary.ts
@@ -419,7 +419,7 @@ export function getTransformationsFromInputs(inputs: Inputs) {
     transformations.push({
       height: maxSize.height,
       width: maxSize.width,
-      crop: 'limit',
+      crop: maxSize.crop || 'limit',
       dpr: maxSize.dpr
     })
   }

--- a/netlify-plugin-cloudinary/src/types/integration.ts
+++ b/netlify-plugin-cloudinary/src/types/integration.ts
@@ -10,9 +10,10 @@ export type Inputs = {
   imagesPath: string | Array<string>;
   loadingStrategy: string;
   maxSize: {
+    crop: string;
     dpr: number | string;
-    height: number;
-    width: number;
+    height: number | string;
+    width: number | string;
   };
   privateCdn: boolean;
   uploadPreset: string;


### PR DESCRIPTION
# Description

The following changes allow users to follow the suggestions outlined in [How to Scale an Image Automatically using Client Hints](https://cloudinary.com/blog/automatic_responsive_images_with_client_hints), specifically:

1. [Scaling an image's width automatically (e.g. 100vw returns an image that is the same width as the viewport)](https://cloudinary.com/blog/automatic_responsive_images_with_client_hints#how_to_scale_an_image_with_automatic_width)
2. [Avoiding cache misses through advanced usage](https://cloudinary.com/blog/automatic_responsive_images_with_client_hints#advanced_w_auto_usage), which allows users to determine the "jumps" between image resource sizes

Changes made:

1. Accept string or number Inputs for maxSize.height and maxSize.width via netlify.toml
2. Accept string Inputs for maxSize.crop via netlify.toml

## Issue Ticket Number

Fixes https://github.com/cloudinary-community/netlify-plugin-cloudinary/issues/104

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have created an [issue](https://github.com/colbyfayock/netlify-plugin-cloudinary/issues) ticket for this PR
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/netlify-plugin-cloudinary/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
